### PR TITLE
Correcting arity error.

### DIFF
--- a/use-package-secret.el
+++ b/use-package-secret.el
@@ -226,7 +226,7 @@ Normal form is (variable)"
 
          ((listp x)
           (setq args*
-                (push (use-package-secret-normalize name label x) args* t))
+                (push (use-package-secret-normalize name label x) args*))
           (setq arg (cdr arg)))
          (t
           (use-package-secret-error


### PR DESCRIPTION
`push` only takes two parameters. I assume the `t` there was leftover from development and wants to be removed.